### PR TITLE
More tight select to archive.

### DIFF
--- a/create-batch
+++ b/create-batch
@@ -516,11 +516,11 @@ transfer_input_files = job.tar.gz"""
         tmpFile.close()
 
         print "@@ Archive files for job submission..." 
-        exclCommon = "--exclude tmp --exclude 'job.tar' --exclude 'job.tar.gz' --exclude .git"
+        exclCommon = "--exclude tmp --exclude 'job.tar' --exclude 'job.tar.gz' --exclude-vcs"
         os.system("tar cf {0}/job.tar {1} --xform='s:{1}:{2}:' -P ".format(self.jobDir, self.cmsswBase, os.path.basename(self.cmsswBase))
-                 + exclCommon + " --exclude-tag-all=.create-batch ")
+                 + exclCommon + " --exclude-tag-all=.create-batch --exclude-tag-all=.requestcache ")
         os.system("tar rf {0}/job.tar {0} --xform='s:{1}:{2}:' -P ".format(self.jobDir, self.cmsswBase, os.path.basename(self.cmsswBase))
-                 + exclCommon)
+                 + exclCommon + " --exclude=*.root")
         os.system("gzip %s/job.tar" % self.jobDir)
         #os.system("rm -f %s/job_*_cfg.py" % self.jobDir)
 


### PR DESCRIPTION
   * CRAB 관련 디렉토리도 뺄 수 있도록 설정
   * 혹시라도 job디렉토리에 .root가 들어있다면 무시
   * .git뿐만 아니라 vcs 전체를 막도록 설정 ( 최신 버전 tar이라면 .gitignore 등도 포함 )