### PR TITLE
New brilcalc

### DIFF
--- a/runLumiCalc
+++ b/runLumiCalc
@@ -2,14 +2,14 @@
 
 if [ $# -lt 1 ]; then
     echo "Usage: runLumiCalc normtag"
-    echo "Usage: runLumiCalc lumi NORMTAG YOUR_LUMI_JSON_FILE"
+    echo "Usage: runLumiCalc NORMTAG YOUR_LUMI_JSON_FILE"
     exit 1
 fi
 
 BRILOPTS=""
 if [ -d /afs/cern.ch/cms -a -d /afs/cern.ch/user ]; then
-    BRILPATH=/afs/cern.ch/cms/lumi/brilconda-1.0.3/bin
-    TAGPATH=/afs/cern.ch/user/l/lumipro/public/normtag_file
+    BRILPATH=/afs/cern.ch/cms/lumi/brilconda-1.1.7/bin
+    TAGPATH=/afs/cern.ch/user/l/lumipro/public/Normtags
 else
     if [ ! -d ~/.lumiCalc/brilconda ]; then
         echo "!!! Cannot find brilcalc executables. Install it"
@@ -17,14 +17,18 @@ else
         sh Brilconda-1.1.7-Linux-x86_64.sh -p ~/.lumiCalc/brilconda
         [ -f Brilconda-1.1.7-Linux-x86_64.sh ] && rm -f Brilconda-1.1.7-Linux-x86_64.sh
     fi
-    if [ ! -d ~/.lumiCalc/normtag_file ]; then
+    if [ ! -d ~/.lumiCalc/Normtags ]; then
         echo "!!! Cannot find normtags. Copying files to ~/.lumiCalc"
         [ -d ~/.lumiCalc ] || mkdir ~/.lumiCalc
-        scp -r lxplus.cern.ch:/afs/cern.ch/user/l/lumipro/public/normtag_file ~/.lumiCalc
+        scp -r lxplus.cern.ch:/afs/cern.ch/user/l/lumipro/public/Normtags ~/.lumiCalc
     fi
     BRILPATH=~/.lumiCalc/brilconda/bin
-    TAGPATH=~/.lumiCalc/normtag_file
+    TAGPATH=~/.lumiCalc/Normtags
     BRILOPTS="-c web"
+
+    if [ -f /cvmfs/cms.cern.ch/SITECONF/local/JobConfig/site-local-config.xml ]; then
+        BRILOPTS="-c /cvmfs/cms.cern.ch/SITECONF/local/JobConfig/site-local-config.xml"
+    fi
 fi
 
 OPT=$1
@@ -38,10 +42,15 @@ else
         exit 1
     fi
 
-    TAGFILE=$TAGPATH/$1
-    if [ ! -f $TAGFILE ]; then
-        echo "!!! Cannot find normtag file. Please check spelling"
-        exit 3
+    if [ -f $1 ]; then
+        TAGFILE=$1
+    else
+        TAGFILE=$TAGPATH/$1
+        if [ ! -f $TAGFILE ]; then
+            echo "!!! Cannot find normtag file. Please check spelling"
+            echo $TAGPATH $1
+            exit 3
+        fi
     fi
     LUMIFILE=$2
     if [ ! -f $LUMIFILE ]; then


### PR DESCRIPTION
Few changes in the recent brilcalc + minor fixes

- brilcalc upgrade to 1.1.7 (previously 1.0.3)
- New official normtag file location
- Normtag file location can be absolute path or just a filename in the official directory
- brilcalc can retrieve lumiDB from the local sites (site-config-local.xml must be configured)
- fix misleading help message