### PR TITLE
Add gsiftp url for mkdir

### DIFF
--- a/create-batch
+++ b/create-batch
@@ -253,8 +253,9 @@ class TheJobConfig:
                 os.system("export LD_PRELOAD=/usr/lib64/libXrdPosixPreload.so; mkdir %s" % dest)
                 
             else:
-                print "gfal-mkdir %s" % dest
-                os.system("gfal-mkdir %s" % dest)
+                if '/store/' in destDir: destDir = '/store/'+destDir.split('/store/', 1)[-1]
+                print "gfal-mkdir gsiftp://cms-se.sdfarm.kr//xrootd/%s" % (destDir)
+                os.system("gfal-mkdir gsiftp://cms-se.sdfarm.kr//xrootd/%s" % destDir)
 
         if hasattr(self, 'process'):
             ## Load cfg file


### PR DESCRIPTION
해당 코드는 gfal-mkdir로 디렉토리를 만들 때 root 프로토콜과 gsiftp 프로토콜 경로의 차이를 위해 하드코딩되었습니다. 해당 코드는 xrdcp를 변경하지 않고는 한번만 사용되기 때문에 하드코딩을 해도 무방하리라 생각됩니다.